### PR TITLE
Basic template pattern for personal pages

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,6 +5,16 @@ from dotenv import load_dotenv
 load_dotenv()
 app = Flask(__name__)
 
+name = "Name"
+experience_list = ["Experience 1", "Experience 2", "Experience 3"]
+education_list = ["Education 1"]
+hobby_list = ["Hobby 1", "Hobby 2", "Hobby 3", "Hobby 4"]
+
+# Example for one person
+# name = "Lauren Ciha"
+# experience_list = ["Schloss Visual Reasoning Lab", "People and Robots Lab", "MLH Fellowship!"]
+# education_list = ["University of Wisconsin-Madison"]
+# hobby_list = ["reading", "journaling", "running"]
 
 @app.route('/')
 def index():
@@ -13,3 +23,11 @@ def index():
 @app.route('/home')
 def home():
     return render_template('home.html', title="Home Page", url=os.getenv("URL"))
+
+@app.route('/sample')
+def template_test():
+    return render_template('sample_page.html', name = name, experience_list=experience_list, education_list=education_list, hobby_list = hobby_list, url=os.getenv("URL"))
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Flask Template Example</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" rel="stylesheet" media="screen">
+    <style type="text/css">
+      .container {
+        max-width: 500px;
+        padding-top: 100px;
+      }
+      h2 {color: red;}
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h2> {{name}} </h2>
+      <br>
+      {% block content %}{% endblock %}
+      <br>
+      <h2>End of base template</h2>
+    </div>
+    <script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
+    <script src="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/app/templates/sample_page.html
+++ b/app/templates/sample_page.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta property="og:title" content="Personal Portfolio">
+    <meta property="og:description" content="My Personal Portfolio">
+    <meta property="og:url" content="{{ url }}">
+    <title>Sample Page</title>
+</head>
+
+  <body>
+    <div class="container">
+        <br>
+            {% extends "layout.html" %}
+            {% block content %}
+            <h3> Experience </h3>
+            <ul>
+                {% for n in experience_list %}
+                <li>{{n}}</li>
+                {% endfor %}
+            </ul>
+            <h3>Education</h3>
+            <ul>
+                {% for n in education_list %}
+                <li>{{n}}</li>
+                {% endfor %}
+            </ul>
+            <h3>Hobbies</h3>
+            <ul>
+                {% for n in hobby_list %}
+                <li>{{n}}</li>
+                {% endfor %}
+            </ul>
+            <h3> This is the end of my child template</h3>{% endblock %}
+        <br>
+    </div>
+    <script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
+    <script src="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
This commit has two templates:

1.  A base template (layout.html)
2. A child template (part of sample_page.html)

The child template fits inside the base template.

Right now, the child template has a bulleted list for Experiences, Education, and Hobbies. If we wanted, we could create a template for each category adjust sample_page.html accordingly. Let me know what you think!